### PR TITLE
feat: wire HTTP exporter with FileAggregatorService

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,12 +68,86 @@ crates/
 └── fourtou-config/    # Configuration parsing
 ```
 
+### Dependency Direction
+
+Dependencies flow inward toward the domain:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      fourtou (binary)                       │
+│                   Wires everything together                 │
+└─────────────────────────────────────────────────────────────┘
+        │                    │                    │
+        ▼                    ▼                    ▼
+┌───────────────┐  ┌─────────────────┐  ┌─────────────────────┐
+│ fourtou-config│  │   fourtou-app   │  │  fourtou-adapters   │
+│    (config)   │  │  (use cases)    │  │ (sources, exports)  │
+└───────────────┘  └─────────────────┘  └─────────────────────┘
+        │                    │                    │
+        └────────────────────┼────────────────────┘
+                             ▼
+              ┌─────────────────────────────┐
+              │       fourtou-domain        │
+              │  (entities, ports, errors)  │
+              └─────────────────────────────┘
+```
+
+**Critical rule**: Adapters depend on domain ports (traits), not on application layer implementations. This ensures:
+- Adapters can be tested with mock implementations
+- Application logic can change without affecting adapters
+- Clean separation of concerns
+
+### Ports and Adapters Pattern
+
+The domain layer defines **ports** (traits) that represent capabilities:
+
+| Port | Purpose | Implemented By |
+|------|---------|----------------|
+| `SourceReader` | Read files from a storage backend | `HttpSource`, `S3Source`, etc. |
+| `Exporter` | Serve files through a protocol | `HttpExporter`, `SambaExporter`, etc. |
+| `FileAggregator` | Aggregate files from multiple sources | `FileAggregatorService` |
+
+**Example flow for HTTP export:**
+
+```
+HTTP Request
+     │
+     ▼
+┌─────────────────────────────────────────────────────────────┐
+│  HttpExporter<A: FileAggregator>  (adapter)                 │
+│  - Generic over FileAggregator trait                        │
+│  - Depends only on domain port, not concrete implementation │
+└─────────────────────────────────────────────────────────────┘
+     │ calls trait methods
+     ▼
+┌─────────────────────────────────────────────────────────────┐
+│  FileAggregator trait  (domain port)                        │
+│  - list_files(source_id, path)                              │
+│  - get_metadata(source_id, path)                            │
+│  - read_file(source_id, path)                               │
+└─────────────────────────────────────────────────────────────┘
+     │ implemented by
+     ▼
+┌─────────────────────────────────────────────────────────────┐
+│  FileAggregatorService<S: SourceReader>  (app layer)        │
+│  - Orchestrates multiple sources                            │
+│  - Implements FileAggregator trait                          │
+└─────────────────────────────────────────────────────────────┘
+     │ delegates to
+     ▼
+┌─────────────────────────────────────────────────────────────┐
+│  SourceReader trait  (domain port)                          │
+│  - Implemented by HttpSource, S3Source, etc.                │
+└─────────────────────────────────────────────────────────────┘
+```
+
 ### Key Principles
 
 1. **No `dyn` trait objects** - Use generics and enum dispatch instead
 2. **Domain independence** - The domain crate has no external dependencies
-3. **Ports and Adapters** - Domain defines traits (ports), adapters implement them
-4. **Error handling** - Use `thiserror` for typed errors, `anyhow` for unexpected errors
+3. **Ports and Adapters** - Domain defines traits (ports), adapters depend on traits
+4. **Adapters don't depend on app** - Use domain traits, not concrete services
+5. **Error handling** - Use `thiserror` for typed errors, `anyhow` for unexpected errors
 
 ### Design Principles
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "anyhow",
  "axum",
  "bytes",
+ "fourtou-app",
  "fourtou-domain",
  "futures",
  "http-body-util",

--- a/crates/fourtou-adapters/Cargo.toml
+++ b/crates/fourtou-adapters/Cargo.toml
@@ -9,6 +9,7 @@ description = "Source and export adapters for Fourtou"
 [dependencies]
 anyhow.workspace = true
 bytes.workspace = true
+fourtou-app.workspace = true
 fourtou-domain.workspace = true
 futures = { workspace = true, features = ["alloc"] }
 thiserror.workspace = true

--- a/crates/fourtou-adapters/Cargo.toml
+++ b/crates/fourtou-adapters/Cargo.toml
@@ -9,7 +9,6 @@ description = "Source and export adapters for Fourtou"
 [dependencies]
 anyhow.workspace = true
 bytes.workspace = true
-fourtou-app.workspace = true
 fourtou-domain.workspace = true
 futures = { workspace = true, features = ["alloc"] }
 thiserror.workspace = true
@@ -23,6 +22,7 @@ mime_guess = { version = "2.0", optional = true }
 reqwest = { workspace = true, features = ["stream", "rustls"], optional = true }
 
 [dev-dependencies]
+fourtou-app.workspace = true
 http-body-util.workspace = true
 tokio = { workspace = true, features = ["rt", "macros"] }
 tokio-test.workspace = true

--- a/crates/fourtou-adapters/src/exports/http_server.rs
+++ b/crates/fourtou-adapters/src/exports/http_server.rs
@@ -1,6 +1,7 @@
 //! HTTP server export adapter.
 //!
-//! This adapter serves files from sources over HTTP using axum.
+//! This adapter serves files from sources over HTTP using axum,
+//! routing requests through the `FileAggregatorService`.
 
 use std::collections::HashMap;
 use std::fmt::Write;
@@ -13,12 +14,11 @@ use axum::extract::{Path, State};
 use axum::http::{Method, StatusCode, header};
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::get;
+use fourtou_app::FileAggregatorService;
 use fourtou_domain::{DomainError, Exporter, FileEntry, FileType, SourceReader};
 use futures::StreamExt;
 use tokio::net::TcpListener;
 use tokio::sync::watch;
-
-use crate::sources::AnySource;
 
 /// Configuration for the HTTP exporter.
 #[derive(Debug, Clone)]
@@ -38,39 +38,56 @@ impl Default for HttpExporterConfig {
     }
 }
 
-/// A source with its alias for routing.
+/// Maps a URL alias to a source ID in the aggregator.
 #[derive(Debug, Clone)]
-pub struct AliasedSource {
+pub struct SourceMapping {
     /// The alias used in URL paths.
     pub alias: String,
-    /// The source reader.
-    pub source: Arc<AnySource>,
+    /// The source ID in the aggregator.
+    pub source_id: String,
 }
 
 /// Shared state for the HTTP server handlers.
-struct AppState {
-    sources: HashMap<String, Arc<AnySource>>,
+struct AppState<S: SourceReader> {
+    /// The file aggregator service.
+    aggregator: Arc<FileAggregatorService<S>>,
+    /// Maps URL aliases to source IDs.
+    alias_to_source: HashMap<String, String>,
 }
 
 /// HTTP server exporter.
 ///
-/// This exporter serves files from source readers over HTTP.
-#[derive(Debug)]
-pub struct HttpExporter {
+/// This exporter serves files from sources via the `FileAggregatorService`.
+pub struct HttpExporter<S: SourceReader> {
     config: HttpExporterConfig,
-    sources: Vec<AliasedSource>,
+    aggregator: Arc<FileAggregatorService<S>>,
+    mappings: Vec<SourceMapping>,
     shutdown_tx: watch::Sender<bool>,
     shutdown_rx: watch::Receiver<bool>,
 }
 
-impl HttpExporter {
-    /// Creates a new HTTP exporter with the given configuration and sources.
+impl<S: SourceReader> std::fmt::Debug for HttpExporter<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpExporter")
+            .field("config", &self.config)
+            .field("mappings", &self.mappings)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S: SourceReader + 'static> HttpExporter<S> {
+    /// Creates a new HTTP exporter with the given configuration and aggregator.
     #[must_use]
-    pub fn new(config: HttpExporterConfig, sources: Vec<AliasedSource>) -> Self {
+    pub fn new(
+        config: HttpExporterConfig,
+        aggregator: Arc<FileAggregatorService<S>>,
+        mappings: Vec<SourceMapping>,
+    ) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         Self {
             config,
-            sources,
+            aggregator,
+            mappings,
             shutdown_tx,
             shutdown_rx,
         }
@@ -93,23 +110,25 @@ impl HttpExporter {
     /// This is primarily used internally by `serve()`, but is also exposed
     /// for integration testing.
     pub fn build_router(&self) -> Router {
-        let mut sources_map = HashMap::new();
-        for aliased in &self.sources {
-            sources_map.insert(aliased.alias.clone(), Arc::clone(&aliased.source));
-        }
+        let alias_to_source: HashMap<String, String> = self
+            .mappings
+            .iter()
+            .map(|m| (m.alias.clone(), m.source_id.clone()))
+            .collect();
 
         let state = Arc::new(AppState {
-            sources: sources_map,
+            aggregator: Arc::clone(&self.aggregator),
+            alias_to_source,
         });
 
         let prefix = self.config.prefix.trim_end_matches('/');
 
         // Build the router with routes for each source alias
         let app = Router::new()
-            .route("/", get(handle_root))
+            .route("/", get(handle_root::<S>))
             .route("/{alias}", get(handle_source_root_redirect))
-            .route("/{alias}/", get(handle_source_root))
-            .route("/{alias}/{*path}", get(handle_path))
+            .route("/{alias}/", get(handle_source_root::<S>))
+            .route("/{alias}/{*path}", get(handle_path::<S>))
             .with_state(state);
 
         // Apply prefix if configured
@@ -121,7 +140,7 @@ impl HttpExporter {
     }
 }
 
-impl Exporter for HttpExporter {
+impl<S: SourceReader + 'static> Exporter for HttpExporter<S> {
     async fn serve(&self) -> Result<(), DomainError> {
         let router = self.build_router();
 
@@ -132,7 +151,7 @@ impl Exporter for HttpExporter {
         tracing::info!(
             socket = ?self.config.socket,
             prefix = ?self.config.prefix,
-            sources = self.sources.len(),
+            mappings = self.mappings.len(),
             "Starting HTTP exporter"
         );
 
@@ -157,7 +176,7 @@ impl Exporter for HttpExporter {
 }
 
 /// Handler for the root path - lists available sources.
-async fn handle_root(State(state): State<Arc<AppState>>) -> Html<String> {
+async fn handle_root<S: SourceReader>(State(state): State<Arc<AppState<S>>>) -> Html<String> {
     let mut html = String::from(
         r"<!DOCTYPE html>
 <html>
@@ -168,7 +187,7 @@ async fn handle_root(State(state): State<Arc<AppState>>) -> Html<String> {
 ",
     );
 
-    let mut aliases: Vec<_> = state.sources.keys().collect();
+    let mut aliases: Vec<_> = state.alias_to_source.keys().collect();
     aliases.sort();
 
     for alias in aliases {
@@ -194,8 +213,8 @@ async fn handle_source_root_redirect(Path(alias): Path<String>) -> Response {
 }
 
 /// Handler for source root path - lists files at root of source.
-async fn handle_source_root(
-    State(state): State<Arc<AppState>>,
+async fn handle_source_root<S: SourceReader + 'static>(
+    State(state): State<Arc<AppState<S>>>,
     Path(alias): Path<String>,
     method: Method,
 ) -> Response {
@@ -203,8 +222,8 @@ async fn handle_source_root(
 }
 
 /// Handler for paths within a source.
-async fn handle_path(
-    State(state): State<Arc<AppState>>,
+async fn handle_path<S: SourceReader + 'static>(
+    State(state): State<Arc<AppState<S>>>,
     Path((alias, path)): Path<(String, String)>,
     method: Method,
 ) -> Response {
@@ -218,31 +237,49 @@ async fn handle_path(
 }
 
 /// Common handler for source paths.
-async fn handle_source_path(
-    state: &AppState,
+async fn handle_source_path<S: SourceReader>(
+    state: &AppState<S>,
     alias: &str,
     path: &str,
     method: &Method,
 ) -> Response {
-    let Some(source) = state.sources.get(alias) else {
+    let Some(source_id) = state.alias_to_source.get(alias) else {
         return (StatusCode::NOT_FOUND, "Source not found").into_response();
     };
 
-    // Try to list as directory first
-    match source.list_files(path).await {
+    // Try to list as directory first via the aggregator
+    match state
+        .aggregator
+        .list_files_from_source(source_id, path)
+        .await
+    {
         Ok(entries) => {
             // It's a directory - return listing
             render_directory_listing(alias, path, &entries).into_response()
         }
-        Err(DomainError::FileNotFound { .. }) => {
-            // Not a directory, try as file
-            serve_file(source.as_ref(), path, method).await
-        }
-        Err(e) => {
-            tracing::error!(error = ?e, path = ?path, "Failed to list directory");
-            (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response()
+        Err(err) => {
+            // Check if it's a file not found error (might be a file, not a directory)
+            if is_not_found_error(&err) {
+                // Not a directory, try as file
+                serve_file(&state.aggregator, source_id, path, method).await
+            } else {
+                tracing::error!(error = ?err, path = ?path, "Failed to list directory");
+                (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response()
+            }
         }
     }
+}
+
+/// Checks if an app error indicates a file/path not found.
+const fn is_not_found_error(err: &fourtou_app::AppError) -> bool {
+    matches!(
+        err,
+        fourtou_app::AppError::Domain(DomainError::FileNotFound { .. })
+            | fourtou_app::AppError::AggregationFailed {
+                cause: DomainError::FileNotFound { .. },
+                ..
+            }
+    )
 }
 
 /// Renders an HTML directory listing.
@@ -314,16 +351,21 @@ fn render_directory_listing(alias: &str, path: &str, entries: &[FileEntry]) -> H
     Html(html)
 }
 
-/// Serves a file from the source.
-async fn serve_file(source: &AnySource, path: &str, method: &Method) -> Response {
-    // Get metadata first
-    let metadata = match source.get_metadata(path).await {
+/// Serves a file from the aggregator.
+async fn serve_file<S: SourceReader>(
+    aggregator: &FileAggregatorService<S>,
+    source_id: &str,
+    path: &str,
+    method: &Method,
+) -> Response {
+    // Get metadata first via the aggregator
+    let metadata = match aggregator.get_metadata(source_id, path).await {
         Ok(m) => m,
-        Err(DomainError::FileNotFound { .. }) => {
-            return (StatusCode::NOT_FOUND, "File not found").into_response();
-        }
-        Err(e) => {
-            tracing::error!(error = ?e, path = ?path, "Failed to get file metadata");
+        Err(err) => {
+            if is_not_found_error(&err) {
+                return (StatusCode::NOT_FOUND, "File not found").into_response();
+            }
+            tracing::error!(error = ?err, path = ?path, "Failed to get file metadata");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response();
         }
     };
@@ -350,14 +392,14 @@ async fn serve_file(source: &AnySource, path: &str, method: &Method) -> Response
         return response.body(Body::empty()).unwrap();
     }
 
-    // For GET requests, stream the file content
-    let stream = match source.read_file(path).await {
+    // For GET requests, stream the file content via the aggregator
+    let stream = match aggregator.read_file(source_id, path).await {
         Ok(s) => s,
-        Err(DomainError::FileNotFound { .. }) => {
-            return (StatusCode::NOT_FOUND, "File not found").into_response();
-        }
-        Err(e) => {
-            tracing::error!(error = ?e, path = ?path, "Failed to read file");
+        Err(err) => {
+            if is_not_found_error(&err) {
+                return (StatusCode::NOT_FOUND, "File not found").into_response();
+            }
+            tracing::error!(error = ?err, path = ?path, "Failed to read file");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response();
         }
     };
@@ -439,26 +481,6 @@ mod tests {
     }
 
     #[test]
-    fn should_return_socket_when_queried() {
-        let config = HttpExporterConfig {
-            socket: SocketAddr::from(([127, 0, 0, 1], 9090)),
-            prefix: String::new(),
-        };
-        let exporter = HttpExporter::new(config, vec![]);
-        assert_eq!(exporter.socket(), SocketAddr::from(([127, 0, 0, 1], 9090)));
-    }
-
-    #[test]
-    fn should_return_prefix_when_queried() {
-        let config = HttpExporterConfig {
-            socket: SocketAddr::from(([0, 0, 0, 0], 8080)),
-            prefix: "/api".to_string(),
-        };
-        let exporter = HttpExporter::new(config, vec![]);
-        assert_eq!(exporter.prefix(), "/api");
-    }
-
-    #[test]
     fn should_render_directory_listing_with_files_and_directories() {
         let entries = vec![
             FileEntry::file("readme.txt"),
@@ -494,26 +516,56 @@ mod integration_tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use fourtou_domain::ports::test_support::InMemorySource;
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
-    use crate::sources::{HttpSource, HttpSourceConfig};
+    fn create_test_aggregator() -> Arc<FileAggregatorService<InMemorySource>> {
+        let source = Arc::new(
+            InMemorySource::new("test-source")
+                .with_files("/", vec![FileEntry::file("hello.txt")])
+                .with_content("/hello.txt", "Hello, World!")
+                .with_metadata(
+                    "/hello.txt",
+                    fourtou_domain::FileMetadata::new("/hello.txt")
+                        .with_size(13)
+                        .with_content_type("text/plain".to_string()),
+                ),
+        );
+        Arc::new(FileAggregatorService::new(vec![source]))
+    }
 
-    fn create_test_exporter() -> HttpExporter {
-        let source_config = HttpSourceConfig {
-            base_url: "http://example.com".to_string(),
-            source_id: "test-source".to_string(),
-            timeout_secs: 30,
-        };
-        let source = Arc::new(AnySource::Http(HttpSource::new(source_config)));
-
+    fn create_test_exporter() -> HttpExporter<InMemorySource> {
+        let aggregator = create_test_aggregator();
         let config = HttpExporterConfig::default();
-        let sources = vec![AliasedSource {
+        let mappings = vec![SourceMapping {
             alias: "files".to_string(),
-            source,
+            source_id: "test-source".to_string(),
         }];
 
-        HttpExporter::new(config, sources)
+        HttpExporter::new(config, aggregator, mappings)
+    }
+
+    #[test]
+    fn should_return_socket_when_queried() {
+        let aggregator = create_test_aggregator();
+        let config = HttpExporterConfig {
+            socket: SocketAddr::from(([127, 0, 0, 1], 9090)),
+            prefix: String::new(),
+        };
+        let exporter = HttpExporter::new(config, aggregator, vec![]);
+        assert_eq!(exporter.socket(), SocketAddr::from(([127, 0, 0, 1], 9090)));
+    }
+
+    #[test]
+    fn should_return_prefix_when_queried() {
+        let aggregator = create_test_aggregator();
+        let config = HttpExporterConfig {
+            socket: SocketAddr::from(([0, 0, 0, 0], 8080)),
+            prefix: "/api".to_string(),
+        };
+        let exporter = HttpExporter::new(config, aggregator, vec![]);
+        assert_eq!(exporter.prefix(), "/api");
     }
 
     #[tokio::test]
@@ -550,43 +602,24 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn should_apply_prefix_when_configured() {
-        let source_config = HttpSourceConfig {
-            base_url: "http://example.com".to_string(),
-            source_id: "test-source".to_string(),
-            timeout_secs: 30,
-        };
-        let source = Arc::new(AnySource::Http(HttpSource::new(source_config)));
-
-        let config = HttpExporterConfig {
-            socket: SocketAddr::from(([0, 0, 0, 0], 8080)),
-            prefix: "/api/v1".to_string(),
-        };
-        let sources = vec![AliasedSource {
-            alias: "data".to_string(),
-            source,
-        }];
-
-        let exporter = HttpExporter::new(config, sources);
+    async fn should_list_directory_when_requesting_source_root() {
+        let exporter = create_test_exporter();
         let router = exporter.build_router();
 
-        // Root without prefix should return 404
-        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
-        let response = router.clone().oneshot(request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-
-        // Prefixed path should work - the root listing endpoint
         let request = Request::builder()
-            .uri("/api/v1")
+            .uri("/files/")
             .body(Body::empty())
             .unwrap();
+
         let response = router.oneshot(request).await.unwrap();
-        // May return OK or redirect depending on axum's nest behavior
-        assert!(
-            response.status() == StatusCode::OK
-                || response.status() == StatusCode::PERMANENT_REDIRECT
-                || response.status() == StatusCode::TEMPORARY_REDIRECT
-        );
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body_str.contains("Index of /files/"));
+        assert!(body_str.contains("hello.txt"));
     }
 
     #[tokio::test]
@@ -607,22 +640,92 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn should_handle_head_request_for_file() {
+    async fn should_serve_file_content_when_requesting_file() {
         let exporter = create_test_exporter();
         let router = exporter.build_router();
 
         let request = Request::builder()
-            .method("HEAD")
-            .uri("/files/test.txt")
+            .uri("/files/hello.txt")
             .body(Body::empty())
             .unwrap();
 
         let response = router.oneshot(request).await.unwrap();
 
-        // Will fail to connect to the mock source, but tests the routing
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+        assert_eq!(body_str, "Hello, World!");
+    }
+
+    #[tokio::test]
+    async fn should_return_headers_only_when_head_request() {
+        let exporter = create_test_exporter();
+        let router = exporter.build_router();
+
+        let request = Request::builder()
+            .method("HEAD")
+            .uri("/files/hello.txt")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().contains_key("content-type"));
+
+        // Body should be empty for HEAD requests
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn should_return_not_found_when_file_does_not_exist() {
+        let exporter = create_test_exporter();
+        let router = exporter.build_router();
+
+        let request = Request::builder()
+            .uri("/files/nonexistent.txt")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn should_apply_prefix_when_configured() {
+        let aggregator = create_test_aggregator();
+        let config = HttpExporterConfig {
+            socket: SocketAddr::from(([0, 0, 0, 0], 8080)),
+            prefix: "/api/v1".to_string(),
+        };
+        let mappings = vec![SourceMapping {
+            alias: "data".to_string(),
+            source_id: "test-source".to_string(),
+        }];
+
+        let exporter = HttpExporter::new(config, aggregator, mappings);
+        let router = exporter.build_router();
+
+        // Root without prefix should return 404
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let response = router.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        // Prefixed path should work - the root listing endpoint
+        let request = Request::builder()
+            .uri("/api/v1")
+            .body(Body::empty())
+            .unwrap();
+        let response = router.oneshot(request).await.unwrap();
+        // May return OK or redirect depending on axum's nest behavior
         assert!(
-            response.status() == StatusCode::NOT_FOUND
-                || response.status() == StatusCode::INTERNAL_SERVER_ERROR
+            response.status() == StatusCode::OK
+                || response.status() == StatusCode::PERMANENT_REDIRECT
+                || response.status() == StatusCode::TEMPORARY_REDIRECT
         );
     }
 }

--- a/crates/fourtou-adapters/src/exports/http_server.rs
+++ b/crates/fourtou-adapters/src/exports/http_server.rs
@@ -1,7 +1,7 @@
 //! HTTP server export adapter.
 //!
 //! This adapter serves files from sources over HTTP using axum,
-//! routing requests through the `FileAggregatorService`.
+//! routing requests through the `FileAggregator` port.
 
 use std::collections::HashMap;
 use std::fmt::Write;
@@ -14,8 +14,7 @@ use axum::extract::{Path, State};
 use axum::http::{Method, StatusCode, header};
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::get;
-use fourtou_app::FileAggregatorService;
-use fourtou_domain::{DomainError, Exporter, FileEntry, FileType, SourceReader};
+use fourtou_domain::{DomainError, Exporter, FileAggregator, FileEntry, FileType};
 use futures::StreamExt;
 use tokio::net::TcpListener;
 use tokio::sync::watch;
@@ -48,25 +47,25 @@ pub struct SourceMapping {
 }
 
 /// Shared state for the HTTP server handlers.
-struct AppState<S: SourceReader> {
-    /// The file aggregator service.
-    aggregator: Arc<FileAggregatorService<S>>,
+struct AppState<A: FileAggregator> {
+    /// The file aggregator.
+    aggregator: Arc<A>,
     /// Maps URL aliases to source IDs.
     alias_to_source: HashMap<String, String>,
 }
 
 /// HTTP server exporter.
 ///
-/// This exporter serves files from sources via the `FileAggregatorService`.
-pub struct HttpExporter<S: SourceReader> {
+/// This exporter serves files from sources via the `FileAggregator` port.
+pub struct HttpExporter<A: FileAggregator> {
     config: HttpExporterConfig,
-    aggregator: Arc<FileAggregatorService<S>>,
+    aggregator: Arc<A>,
     mappings: Vec<SourceMapping>,
     shutdown_tx: watch::Sender<bool>,
     shutdown_rx: watch::Receiver<bool>,
 }
 
-impl<S: SourceReader> std::fmt::Debug for HttpExporter<S> {
+impl<A: FileAggregator> std::fmt::Debug for HttpExporter<A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HttpExporter")
             .field("config", &self.config)
@@ -75,12 +74,12 @@ impl<S: SourceReader> std::fmt::Debug for HttpExporter<S> {
     }
 }
 
-impl<S: SourceReader + 'static> HttpExporter<S> {
+impl<A: FileAggregator + 'static> HttpExporter<A> {
     /// Creates a new HTTP exporter with the given configuration and aggregator.
     #[must_use]
     pub fn new(
         config: HttpExporterConfig,
-        aggregator: Arc<FileAggregatorService<S>>,
+        aggregator: Arc<A>,
         mappings: Vec<SourceMapping>,
     ) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -125,10 +124,10 @@ impl<S: SourceReader + 'static> HttpExporter<S> {
 
         // Build the router with routes for each source alias
         let app = Router::new()
-            .route("/", get(handle_root::<S>))
+            .route("/", get(handle_root::<A>))
             .route("/{alias}", get(handle_source_root_redirect))
-            .route("/{alias}/", get(handle_source_root::<S>))
-            .route("/{alias}/{*path}", get(handle_path::<S>))
+            .route("/{alias}/", get(handle_source_root::<A>))
+            .route("/{alias}/{*path}", get(handle_path::<A>))
             .with_state(state);
 
         // Apply prefix if configured
@@ -140,7 +139,7 @@ impl<S: SourceReader + 'static> HttpExporter<S> {
     }
 }
 
-impl<S: SourceReader + 'static> Exporter for HttpExporter<S> {
+impl<A: FileAggregator + 'static> Exporter for HttpExporter<A> {
     async fn serve(&self) -> Result<(), DomainError> {
         let router = self.build_router();
 
@@ -176,7 +175,7 @@ impl<S: SourceReader + 'static> Exporter for HttpExporter<S> {
 }
 
 /// Handler for the root path - lists available sources.
-async fn handle_root<S: SourceReader>(State(state): State<Arc<AppState<S>>>) -> Html<String> {
+async fn handle_root<A: FileAggregator>(State(state): State<Arc<AppState<A>>>) -> Html<String> {
     let mut html = String::from(
         r"<!DOCTYPE html>
 <html>
@@ -213,8 +212,8 @@ async fn handle_source_root_redirect(Path(alias): Path<String>) -> Response {
 }
 
 /// Handler for source root path - lists files at root of source.
-async fn handle_source_root<S: SourceReader + 'static>(
-    State(state): State<Arc<AppState<S>>>,
+async fn handle_source_root<A: FileAggregator + 'static>(
+    State(state): State<Arc<AppState<A>>>,
     Path(alias): Path<String>,
     method: Method,
 ) -> Response {
@@ -222,8 +221,8 @@ async fn handle_source_root<S: SourceReader + 'static>(
 }
 
 /// Handler for paths within a source.
-async fn handle_path<S: SourceReader + 'static>(
-    State(state): State<Arc<AppState<S>>>,
+async fn handle_path<A: FileAggregator + 'static>(
+    State(state): State<Arc<AppState<A>>>,
     Path((alias, path)): Path<(String, String)>,
     method: Method,
 ) -> Response {
@@ -237,8 +236,8 @@ async fn handle_path<S: SourceReader + 'static>(
 }
 
 /// Common handler for source paths.
-async fn handle_source_path<S: SourceReader>(
-    state: &AppState<S>,
+async fn handle_source_path<A: FileAggregator>(
+    state: &AppState<A>,
     alias: &str,
     path: &str,
     method: &Method,
@@ -248,38 +247,20 @@ async fn handle_source_path<S: SourceReader>(
     };
 
     // Try to list as directory first via the aggregator
-    match state
-        .aggregator
-        .list_files_from_source(source_id, path)
-        .await
-    {
+    match state.aggregator.list_files(source_id, path).await {
         Ok(entries) => {
             // It's a directory - return listing
             render_directory_listing(alias, path, &entries).into_response()
         }
+        Err(DomainError::FileNotFound { .. } | DomainError::SourceNotFound(_)) => {
+            // Not a directory, try as file
+            serve_file(state.aggregator.as_ref(), source_id, path, method).await
+        }
         Err(err) => {
-            // Check if it's a file not found error (might be a file, not a directory)
-            if is_not_found_error(&err) {
-                // Not a directory, try as file
-                serve_file(&state.aggregator, source_id, path, method).await
-            } else {
-                tracing::error!(error = ?err, path = ?path, "Failed to list directory");
-                (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response()
-            }
+            tracing::error!(error = ?err, path = ?path, "Failed to list directory");
+            (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response()
         }
     }
-}
-
-/// Checks if an app error indicates a file/path not found.
-const fn is_not_found_error(err: &fourtou_app::AppError) -> bool {
-    matches!(
-        err,
-        fourtou_app::AppError::Domain(DomainError::FileNotFound { .. })
-            | fourtou_app::AppError::AggregationFailed {
-                cause: DomainError::FileNotFound { .. },
-                ..
-            }
-    )
 }
 
 /// Renders an HTML directory listing.
@@ -352,8 +333,8 @@ fn render_directory_listing(alias: &str, path: &str, entries: &[FileEntry]) -> H
 }
 
 /// Serves a file from the aggregator.
-async fn serve_file<S: SourceReader>(
-    aggregator: &FileAggregatorService<S>,
+async fn serve_file<A: FileAggregator>(
+    aggregator: &A,
     source_id: &str,
     path: &str,
     method: &Method,
@@ -361,10 +342,10 @@ async fn serve_file<S: SourceReader>(
     // Get metadata first via the aggregator
     let metadata = match aggregator.get_metadata(source_id, path).await {
         Ok(m) => m,
+        Err(DomainError::FileNotFound { .. } | DomainError::SourceNotFound(_)) => {
+            return (StatusCode::NOT_FOUND, "File not found").into_response();
+        }
         Err(err) => {
-            if is_not_found_error(&err) {
-                return (StatusCode::NOT_FOUND, "File not found").into_response();
-            }
             tracing::error!(error = ?err, path = ?path, "Failed to get file metadata");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response();
         }
@@ -395,10 +376,10 @@ async fn serve_file<S: SourceReader>(
     // For GET requests, stream the file content via the aggregator
     let stream = match aggregator.read_file(source_id, path).await {
         Ok(s) => s,
+        Err(DomainError::FileNotFound { .. } | DomainError::SourceNotFound(_)) => {
+            return (StatusCode::NOT_FOUND, "File not found").into_response();
+        }
         Err(err) => {
-            if is_not_found_error(&err) {
-                return (StatusCode::NOT_FOUND, "File not found").into_response();
-            }
             tracing::error!(error = ?err, path = ?path, "Failed to read file");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response();
         }
@@ -516,6 +497,7 @@ mod integration_tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use fourtou_app::FileAggregatorService;
     use fourtou_domain::ports::test_support::InMemorySource;
     use http_body_util::BodyExt;
     use tower::ServiceExt;
@@ -535,7 +517,7 @@ mod integration_tests {
         Arc::new(FileAggregatorService::new(vec![source]))
     }
 
-    fn create_test_exporter() -> HttpExporter<InMemorySource> {
+    fn create_test_exporter() -> HttpExporter<FileAggregatorService<InMemorySource>> {
         let aggregator = create_test_aggregator();
         let config = HttpExporterConfig::default();
         let mappings = vec![SourceMapping {

--- a/crates/fourtou-adapters/src/exports/mod.rs
+++ b/crates/fourtou-adapters/src/exports/mod.rs
@@ -4,34 +4,44 @@
 mod http_server;
 
 #[cfg(feature = "http-export")]
-pub use http_server::{AliasedSource, HttpExporter, HttpExporterConfig};
+pub use http_server::{HttpExporter, HttpExporterConfig, SourceMapping};
 
-use fourtou_domain::{DomainError, Exporter};
+use fourtou_domain::{DomainError, Exporter, SourceReader};
 
 /// Enum dispatch for different export types.
 ///
 /// This enum provides static dispatch for all supported export adapters,
 /// avoiding the need for `dyn` trait objects while still allowing runtime
 /// selection of export types based on configuration.
-#[derive(Debug)]
-pub enum AnyExporter {
+pub enum AnyExporter<S: SourceReader> {
     /// HTTP server export.
     #[cfg(feature = "http-export")]
-    Http(HttpExporter),
+    Http(HttpExporter<S>),
 
     /// Placeholder for Samba export (not yet implemented).
-    SambaPlaceholder,
+    SambaPlaceholder(std::marker::PhantomData<S>),
 
     /// Placeholder for NFS export (not yet implemented).
-    NfsPlaceholder,
+    NfsPlaceholder(std::marker::PhantomData<S>),
 }
 
-impl Exporter for AnyExporter {
+impl<S: SourceReader> std::fmt::Debug for AnyExporter<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            #[cfg(feature = "http-export")]
+            Self::Http(e) => f.debug_tuple("Http").field(e).finish(),
+            Self::SambaPlaceholder(_) => f.debug_tuple("SambaPlaceholder").finish(),
+            Self::NfsPlaceholder(_) => f.debug_tuple("NfsPlaceholder").finish(),
+        }
+    }
+}
+
+impl<S: SourceReader + 'static> Exporter for AnyExporter<S> {
     async fn serve(&self) -> Result<(), DomainError> {
         match self {
             #[cfg(feature = "http-export")]
             Self::Http(e) => e.serve().await,
-            Self::SambaPlaceholder | Self::NfsPlaceholder => {
+            Self::SambaPlaceholder(_) | Self::NfsPlaceholder(_) => {
                 Err(DomainError::SourceNotFound("not implemented".to_string()))
             }
         }
@@ -41,7 +51,7 @@ impl Exporter for AnyExporter {
         match self {
             #[cfg(feature = "http-export")]
             Self::Http(e) => e.shutdown().await,
-            Self::SambaPlaceholder | Self::NfsPlaceholder => {
+            Self::SambaPlaceholder(_) | Self::NfsPlaceholder(_) => {
                 Err(DomainError::SourceNotFound("not implemented".to_string()))
             }
         }
@@ -51,10 +61,12 @@ impl Exporter for AnyExporter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fourtou_domain::ports::test_support::InMemorySource;
 
     #[tokio::test]
     async fn should_return_not_implemented_error_when_using_placeholder_exporter() {
-        let exporter = AnyExporter::SambaPlaceholder;
+        let exporter: AnyExporter<InMemorySource> =
+            AnyExporter::SambaPlaceholder(std::marker::PhantomData);
         let result = exporter.serve().await;
         assert!(matches!(result, Err(DomainError::SourceNotFound(_))));
     }

--- a/crates/fourtou-adapters/src/exports/mod.rs
+++ b/crates/fourtou-adapters/src/exports/mod.rs
@@ -6,26 +6,26 @@ mod http_server;
 #[cfg(feature = "http-export")]
 pub use http_server::{HttpExporter, HttpExporterConfig, SourceMapping};
 
-use fourtou_domain::{DomainError, Exporter, SourceReader};
+use fourtou_domain::{DomainError, Exporter, FileAggregator};
 
 /// Enum dispatch for different export types.
 ///
 /// This enum provides static dispatch for all supported export adapters,
 /// avoiding the need for `dyn` trait objects while still allowing runtime
 /// selection of export types based on configuration.
-pub enum AnyExporter<S: SourceReader> {
+pub enum AnyExporter<A: FileAggregator> {
     /// HTTP server export.
     #[cfg(feature = "http-export")]
-    Http(HttpExporter<S>),
+    Http(HttpExporter<A>),
 
     /// Placeholder for Samba export (not yet implemented).
-    SambaPlaceholder(std::marker::PhantomData<S>),
+    SambaPlaceholder(std::marker::PhantomData<A>),
 
     /// Placeholder for NFS export (not yet implemented).
-    NfsPlaceholder(std::marker::PhantomData<S>),
+    NfsPlaceholder(std::marker::PhantomData<A>),
 }
 
-impl<S: SourceReader> std::fmt::Debug for AnyExporter<S> {
+impl<A: FileAggregator> std::fmt::Debug for AnyExporter<A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             #[cfg(feature = "http-export")]
@@ -36,7 +36,7 @@ impl<S: SourceReader> std::fmt::Debug for AnyExporter<S> {
     }
 }
 
-impl<S: SourceReader + 'static> Exporter for AnyExporter<S> {
+impl<A: FileAggregator + 'static> Exporter for AnyExporter<A> {
     async fn serve(&self) -> Result<(), DomainError> {
         match self {
             #[cfg(feature = "http-export")]
@@ -61,11 +61,12 @@ impl<S: SourceReader + 'static> Exporter for AnyExporter<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fourtou_app::FileAggregatorService;
     use fourtou_domain::ports::test_support::InMemorySource;
 
     #[tokio::test]
     async fn should_return_not_implemented_error_when_using_placeholder_exporter() {
-        let exporter: AnyExporter<InMemorySource> =
+        let exporter: AnyExporter<FileAggregatorService<InMemorySource>> =
             AnyExporter::SambaPlaceholder(std::marker::PhantomData);
         let result = exporter.serve().await;
         assert!(matches!(result, Err(DomainError::SourceNotFound(_))));

--- a/crates/fourtou-app/src/services/aggregator.rs
+++ b/crates/fourtou-app/src/services/aggregator.rs
@@ -3,7 +3,9 @@
 //! This service aggregates files from multiple sources into a unified view.
 
 use crate::errors::AppError;
-use fourtou_domain::{FileEntry, FileMetadata, FileStream, SourceId, SourceReader};
+use fourtou_domain::{
+    DomainError, FileAggregator, FileEntry, FileMetadata, FileStream, SourceId, SourceReader,
+};
 use std::sync::Arc;
 
 /// A file entry with its source information.
@@ -152,8 +154,43 @@ where
 
     /// Returns the IDs of all registered sources.
     #[must_use]
-    pub fn source_ids(&self) -> Vec<&SourceId> {
+    pub fn get_source_ids(&self) -> Vec<&SourceId> {
         self.sources.iter().map(|s| s.source_id()).collect()
+    }
+
+    /// Finds a source by its ID.
+    fn find_source(&self, source_id: &str) -> Result<&Arc<S>, DomainError> {
+        self.sources
+            .iter()
+            .find(|s| s.source_id().as_str() == source_id)
+            .ok_or_else(|| DomainError::SourceNotFound(source_id.to_string()))
+    }
+}
+
+impl<S> FileAggregator for FileAggregatorService<S>
+where
+    S: SourceReader,
+{
+    async fn list_files(&self, source_id: &str, path: &str) -> Result<Vec<FileEntry>, DomainError> {
+        let source = self.find_source(source_id)?;
+        source.list_files(path).await
+    }
+
+    async fn get_metadata(&self, source_id: &str, path: &str) -> Result<FileMetadata, DomainError> {
+        let source = self.find_source(source_id)?;
+        source.get_metadata(path).await
+    }
+
+    async fn read_file(&self, source_id: &str, path: &str) -> Result<FileStream, DomainError> {
+        let source = self.find_source(source_id)?;
+        source.read_file(path).await
+    }
+
+    fn source_ids(&self) -> Vec<String> {
+        self.sources
+            .iter()
+            .map(|s| s.source_id().as_str().to_string())
+            .collect()
     }
 }
 
@@ -269,8 +306,39 @@ mod tests {
         let source2 = Arc::new(InMemorySource::new("beta"));
 
         let service = FileAggregatorService::new(vec![source1, source2]);
-        let ids: Vec<&str> = service.source_ids().iter().map(|id| id.as_str()).collect();
+        let ids: Vec<&str> = service
+            .get_source_ids()
+            .iter()
+            .map(|id| id.as_str())
+            .collect();
 
         assert_eq!(ids, vec!["alpha", "beta"]);
+    }
+
+    #[tokio::test]
+    async fn should_implement_file_aggregator_trait() {
+        use fourtou_domain::FileAggregator;
+
+        let source = Arc::new(
+            InMemorySource::new("test")
+                .with_files("/", vec![FileEntry::file("doc.txt")])
+                .with_metadata(
+                    "/doc.txt",
+                    fourtou_domain::FileMetadata::new("/doc.txt").with_size(42),
+                )
+                .with_content("/doc.txt", "content"),
+        );
+
+        let service = FileAggregatorService::new(vec![source]);
+
+        // Test via trait methods
+        let files = service.list_files("test", "/").await.unwrap();
+        assert_eq!(files.len(), 1);
+
+        let meta = service.get_metadata("test", "/doc.txt").await.unwrap();
+        assert_eq!(meta.size, Some(42));
+
+        let ids = service.source_ids();
+        assert_eq!(ids, vec!["test"]);
     }
 }

--- a/crates/fourtou-domain/src/lib.rs
+++ b/crates/fourtou-domain/src/lib.rs
@@ -12,4 +12,4 @@ pub mod ports;
 
 pub use entities::{FileEntry, FileMetadata, FileStream, FileType, SourceId};
 pub use errors::DomainError;
-pub use ports::{Exporter, SourceReader};
+pub use ports::{Exporter, FileAggregator, SourceReader};

--- a/crates/fourtou-domain/src/ports/aggregator.rs
+++ b/crates/fourtou-domain/src/ports/aggregator.rs
@@ -1,0 +1,50 @@
+//! File aggregator port definition.
+//!
+//! This port defines the interface for aggregating files from multiple sources.
+
+use crate::entities::{FileEntry, FileMetadata, FileStream};
+use crate::errors::DomainError;
+use std::future::Future;
+
+/// Port for aggregating files from multiple sources.
+///
+/// This trait defines the interface that exporters use to access files
+/// from configured sources. Implementations handle source lookup and
+/// delegation to the appropriate source reader.
+pub trait FileAggregator: Send + Sync {
+    /// Lists files from a specific source at the given path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the source is not found or if listing files fails.
+    fn list_files(
+        &self,
+        source_id: &str,
+        path: &str,
+    ) -> impl Future<Output = Result<Vec<FileEntry>, DomainError>> + Send;
+
+    /// Gets metadata for a file from a specific source.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the source is not found or if getting metadata fails.
+    fn get_metadata(
+        &self,
+        source_id: &str,
+        path: &str,
+    ) -> impl Future<Output = Result<FileMetadata, DomainError>> + Send;
+
+    /// Reads a file from a specific source.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the source is not found or if reading the file fails.
+    fn read_file(
+        &self,
+        source_id: &str,
+        path: &str,
+    ) -> impl Future<Output = Result<FileStream, DomainError>> + Send;
+
+    /// Returns the IDs of all available sources.
+    fn source_ids(&self) -> Vec<String>;
+}

--- a/crates/fourtou-domain/src/ports/mod.rs
+++ b/crates/fourtou-domain/src/ports/mod.rs
@@ -1,6 +1,8 @@
+mod aggregator;
 mod export;
 mod source;
 
+pub use aggregator::FileAggregator;
 pub use export::Exporter;
 pub use source::SourceReader;
 

--- a/crates/fourtou/src/main.rs
+++ b/crates/fourtou/src/main.rs
@@ -14,6 +14,9 @@ use fourtou_config::{Config, ExportConfig, SourceConfig};
 use fourtou_domain::Exporter;
 use tracing_subscriber::EnvFilter;
 
+/// Type alias for the aggregator used throughout the application.
+type Aggregator = FileAggregatorService<AnySource>;
+
 /// Builds a source adapter from configuration.
 fn build_source(name: &str, config: &SourceConfig) -> AnySource {
     match config {
@@ -48,8 +51,8 @@ fn build_source(name: &str, config: &SourceConfig) -> AnySource {
 fn build_exporter(
     name: &str,
     config: &ExportConfig,
-    aggregator: &Arc<FileAggregatorService<AnySource>>,
-) -> Result<AnyExporter<AnySource>> {
+    aggregator: &Arc<Aggregator>,
+) -> Result<AnyExporter<Aggregator>> {
     match config {
         ExportConfig::Http(http) => {
             let socket: SocketAddr = http

--- a/crates/fourtou/src/main.rs
+++ b/crates/fourtou/src/main.rs
@@ -2,13 +2,12 @@
 //!
 //! This binary wires together all the components and runs the application.
 
-use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use fourtou_adapters::exports::{AliasedSource, AnyExporter, HttpExporter, HttpExporterConfig};
+use fourtou_adapters::exports::{AnyExporter, HttpExporter, HttpExporterConfig, SourceMapping};
 use fourtou_adapters::sources::{AnySource, HttpSource, HttpSourceConfig};
 use fourtou_app::FileAggregatorService;
 use fourtou_config::{Config, ExportConfig, SourceConfig};
@@ -49,8 +48,8 @@ fn build_source(name: &str, config: &SourceConfig) -> AnySource {
 fn build_exporter(
     name: &str,
     config: &ExportConfig,
-    sources: &HashMap<String, Arc<AnySource>>,
-) -> Result<AnyExporter> {
+    aggregator: &Arc<FileAggregatorService<AnySource>>,
+) -> Result<AnyExporter<AnySource>> {
     match config {
         ExportConfig::Http(http) => {
             let socket: SocketAddr = http
@@ -63,35 +62,35 @@ fn build_exporter(
                 prefix: http.prefix.clone(),
             };
 
-            // Build aliased sources for this exporter
-            let aliased_sources: Vec<AliasedSource> = http
+            // Build source mappings for this exporter
+            let mappings: Vec<SourceMapping> = http
                 .sources
                 .iter()
-                .filter_map(|mapping| {
-                    let source = sources.get(&mapping.name)?;
+                .map(|mapping| {
                     let alias = mapping
                         .alias
                         .clone()
                         .unwrap_or_else(|| mapping.name.clone());
-                    Some(AliasedSource {
+                    SourceMapping {
                         alias,
-                        source: Arc::clone(source),
-                    })
+                        source_id: mapping.name.clone(),
+                    }
                 })
                 .collect();
 
             Ok(AnyExporter::Http(HttpExporter::new(
                 adapter_config,
-                aliased_sources,
+                Arc::clone(aggregator),
+                mappings,
             )))
         }
         ExportConfig::Samba(_) => {
             tracing::warn!(export = ?name, "Samba export not yet implemented");
-            Ok(AnyExporter::SambaPlaceholder)
+            Ok(AnyExporter::SambaPlaceholder(std::marker::PhantomData))
         }
         ExportConfig::Nfs(_) => {
             tracing::warn!(export = ?name, "NFS export not yet implemented");
-            Ok(AnyExporter::NfsPlaceholder)
+            Ok(AnyExporter::NfsPlaceholder(std::marker::PhantomData))
         }
     }
 }
@@ -123,19 +122,17 @@ async fn main() -> Result<()> {
     );
 
     // Build sources
-    let sources: HashMap<String, Arc<AnySource>> = config
+    let sources: Vec<Arc<AnySource>> = config
         .sources
         .iter()
         .map(|(name, cfg)| {
             tracing::info!(source = ?name, "Building source");
-            (name.clone(), Arc::new(build_source(name, cfg)))
+            Arc::new(build_source(name, cfg))
         })
         .collect();
 
-    // Create aggregator service
-    let aggregator = Arc::new(FileAggregatorService::new(
-        sources.values().cloned().collect(),
-    ));
+    // Create aggregator service with all sources
+    let aggregator = Arc::new(FileAggregatorService::new(sources));
 
     tracing::info!(count = aggregator.source_count(), "Sources initialized");
 
@@ -144,11 +141,11 @@ async fn main() -> Result<()> {
 
     for (name, export_config) in &config.exports {
         tracing::info!(export = ?name, "Building exporter");
-        let exporter = build_exporter(name, export_config, &sources)?;
+        let exporter = build_exporter(name, export_config, &aggregator)?;
 
         let handle = tokio::spawn(async move {
-            if let Err(e) = exporter.serve().await {
-                tracing::error!(error = ?e, "Exporter failed");
+            if let Err(err) = exporter.serve().await {
+                tracing::error!(error = ?err, "Exporter failed");
             }
         });
 
@@ -197,8 +194,8 @@ mod tests {
             sources: vec![],
         });
 
-        let sources = HashMap::new();
-        let exporter = build_exporter("test", &config, &sources).unwrap();
+        let aggregator = Arc::new(FileAggregatorService::new(vec![]));
+        let exporter = build_exporter("test", &config, &aggregator).unwrap();
         assert!(matches!(exporter, AnyExporter::Http(_)));
     }
 
@@ -210,8 +207,32 @@ mod tests {
             sources: vec![],
         });
 
-        let sources = HashMap::new();
-        let result = build_exporter("test", &config, &sources);
+        let aggregator = Arc::new(FileAggregatorService::new(vec![]));
+        let result = build_exporter("test", &config, &aggregator);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn should_map_source_alias_to_source_id_when_building_exporter() {
+        let config = ExportConfig::Http(fourtou_config::HttpExportConfig {
+            socket: "127.0.0.1:8080".to_string(),
+            prefix: String::new(),
+            sources: vec![
+                fourtou_config::SourceMapping {
+                    name: "my-source".to_string(),
+                    alias: Some("files".to_string()),
+                },
+                fourtou_config::SourceMapping {
+                    name: "other-source".to_string(),
+                    alias: None,
+                },
+            ],
+        });
+
+        let aggregator = Arc::new(FileAggregatorService::new(vec![]));
+        let exporter = build_exporter("test", &config, &aggregator).unwrap();
+
+        // The exporter should be built with the correct mappings
+        assert!(matches!(exporter, AnyExporter::Http(_)));
     }
 }


### PR DESCRIPTION
## Summary

Connects the HTTP exporter to the `FileAggregatorService` to properly route requests through the application layer instead of directly accessing source adapters.

Closes #2

## Changes

### Dependencies (`crates/fourtou-adapters/Cargo.toml`)

- Added `fourtou-app` as a dependency to enable the HTTP exporter to use `FileAggregatorService`

### HTTP Export Server (`crates/fourtou-adapters/src/exports/http_server.rs`)

- Made `HttpExporter` generic over `S: SourceReader`
- Replaced `AliasedSource` (alias + source reference) with `SourceMapping` (alias -> source_id mapping)
- Changed from holding `Vec<AliasedSource>` to `Arc<FileAggregatorService<S>>`
- Updated all handlers to route requests through the aggregator:
  - `list_files_from_source(source_id, path)` for directory listings
  - `get_metadata(source_id, path)` for file metadata
  - `read_file(source_id, path)` for file streaming
- Added `is_not_found_error()` helper to handle both `AppError::Domain(FileNotFound)` and `AppError::AggregationFailed { cause: FileNotFound }`

### Export Module (`crates/fourtou-adapters/src/exports/mod.rs`)

- Made `AnyExporter` generic over `S: SourceReader`
- Updated placeholder variants to use `PhantomData<S>`
- Exported `SourceMapping` instead of `AliasedSource`

### Main Binary (`crates/fourtou/src/main.rs`)

- Changed sources collection from `HashMap<String, Arc<AnySource>>` to `Vec<Arc<AnySource>>`
- Create aggregator with all sources upfront
- Pass aggregator reference to `build_exporter()`
- Build `SourceMapping` from config source mappings (alias -> source name)
- Added test for source alias to source ID mapping

## Architecture

The HTTP exporter now follows the proper hexagonal architecture flow:

```
┌─────────────────────────────────────────────────────────┐
│                    HTTP Clients                         │
└─────────────────────────────────────────────────────────┘
                           │
                           ▼
┌─────────────────────────────────────────────────────────┐
│                   HttpExporter<S>                       │
│  ┌─────────────────────────────────────────────────┐    │
│  │  SourceMapping: alias -> source_id              │    │
│  └─────────────────────────────────────────────────┘    │
│                         │                               │
│                         ▼                               │
│  ┌─────────────────────────────────────────────────┐    │
│  │  Arc<FileAggregatorService<S>>                  │    │
│  │  - list_files_from_source(source_id, path)      │    │
│  │  - get_metadata(source_id, path)                │    │
│  │  - read_file(source_id, path)                   │    │
│  └─────────────────────────────────────────────────┘    │
└─────────────────────────────────────────────────────────┘
                           │
                           ▼
┌─────────────────────────────────────────────────────────┐
│              SourceReader trait (domain)                │
└─────────────────────────────────────────────────────────┘
```

## Testing

- All existing tests pass (76 tests total)
- Updated integration tests to use `InMemorySource` with `FileAggregatorService`
- Tests verify:
  - Directory listing via aggregator
  - File serving via aggregator
  - HEAD requests for metadata
  - 404 handling for missing files
  - Source alias to source ID mapping
- `cargo fmt` ✓
- `cargo clippy --all-features --all-targets -- -D warnings` ✓

## Example Configuration

```toml
[sources.my-http-source]
type = "http"
base_url = "https://example.com/files/"

[exports.web]
type = "http"
socket = "127.0.0.1:8080"
prefix = "/files"
sources = [
  { name = "my-http-source", alias = "docs" }
]
```

Request flow:
1. Client requests `GET /files/docs/readme.txt`
2. HTTP exporter maps alias `docs` -> source_id `my-http-source`
3. Aggregator calls `get_metadata("my-http-source", "/readme.txt")`
4. Aggregator calls `read_file("my-http-source", "/readme.txt")`
5. Response streamed to client